### PR TITLE
make possible to run with karma autoWatch, and with other frameworks

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,16 @@ var BenchReporter = function(baseReporterDecorator) {
 
   var resultSet = {};
 
-  this.onRunComplete = function(browsers, resultInfo) {
-    for (var browserName in resultSet) {
+  this.onRunStart = function(browsers) {
+    resultSet = {};
+  };
+
+  this.onBrowserStart = function(browser) {
+    resultSet[browser.name] = {};
+  };
+
+  this.onBrowserComplete = function(browser) {
+      var browserName = browser.name;
       var groups = resultSet[browserName];
 
       this.write(browserName+'\n');
@@ -27,10 +35,14 @@ var BenchReporter = function(baseReporterDecorator) {
           this.write('  '+results[0].description+' had no peers for comparison at '+Math.floor(results[0].benchmark.hz)+' ops/sec\n')
         }
       }
-    }
   };
 
   this.specSuccess = function(browser, result) {
+    if (!result.benchmark) {
+      // do nothing - assume this result did not come from benchmark framework
+      return;
+    }
+
     var browser = browser.name;
     var suite = result.benchmark.suite;
     var name = result.benchmark.name;


### PR DESCRIPTION
- when using karma autoWatch we need to clear the results of the last run before starting a new one.
- also - if there are other frameworks (such as jasmine) we want to ignore them and only handle results from benchmark
